### PR TITLE
Change license to CC-BY 4.0

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -14,11 +14,11 @@ TurboWarp is also free and [open source](https://github.com/TurboWarp). It is av
 
 ### How do I open your Scratch projects?
 
-See [Downloading and Opening](https://github.com/DNin01/Scratch-projects/blob/main/INSTALLING.md).
+See [Downloading and Opening](./INSTALLING.md).
 
 ### Can I use your work in my projects?
 
-Absolutely! Unless otherwise indicated, everything I made in here is under a [Creative Commons Attribution-ShareAlike 2.0 license](https://creativecommons.org/licenses/by-sa/2.0/legalcode), which, by the way, is the same license user-generated content shared to Scratch use. Check the [README](https://github.com/DNin01/Scratch-projects/blob/main/README.md#license-and-giving-credit) for more details.
+Absolutely! Most of the content in here is under a [Creative Commons Attribution 4.0 license](./LICENSE), but some parts are under different licenses. You should check the license of each individual Scratch project at the bottom of their READMEs to be sure. Check [License and giving credit](https://github.com/DNin01/Scratch-projects/blob/main/README.md#license-and-giving-credit) on the [main README](./README.md) for more details.
 
 ### I have another question.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,252 +1,395 @@
-                         Attribution-ShareAlike 2.0
-   CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
-   LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN
-   ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
-   INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
-   REGARDING THE INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR
-   DAMAGES RESULTING FROM ITS USE.
+Attribution 4.0 International
 
-   License
+=======================================================================
 
-   THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
-   CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS
-   PROTECTED BY COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE
-   WORK OTHER THAN AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS
-   PROHIBITED.
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
 
-   BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND
-   AGREE TO BE BOUND BY THE TERMS OF THIS LICENSE. THE LICENSOR GRANTS
-   YOU THE RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF
-   SUCH TERMS AND CONDITIONS.
+Using Creative Commons Public Licenses
 
-   1. Definitions
-    a. "Collective Work" means a work, such as a periodical issue,
-       anthology or encyclopedia, in which the Work in its entirety in
-       unmodified form, along with a number of other contributions,
-       constituting separate and independent works in themselves, are
-       assembled into a collective whole. A work that constitutes a
-       Collective Work will not be considered a Derivative Work (as
-       defined below) for the purposes of this License.
-    b. "Derivative Work" means a work based upon the Work or upon the
-       Work and other pre-existing works, such as a translation, musical
-       arrangement, dramatization, fictionalization, motion picture
-       version, sound recording, art reproduction, abridgment,
-       condensation, or any other form in which the Work may be recast,
-       transformed, or adapted, except that a work that constitutes a
-       Collective Work will not be considered a Derivative Work for the
-       purpose of this License. For the avoidance of doubt, where the
-       Work is a musical composition or sound recording, the
-       synchronization of the Work in timed-relation with a moving image
-       ("synching") will be considered a Derivative Work for the purpose
-       of this License.
-    c. "Licensor" means the individual or entity that offers the Work
-       under the terms of this License.
-    d. "Original Author" means the individual or entity who created the
-       Work.
-    e. "Work" means the copyrightable work of authorship offered under
-       the terms of this License.
-    f. "You" means an individual or entity exercising rights under this
-       License who has not previously violated the terms of this License
-       with respect to the Work, or who has received express permission
-       from the Licensor to exercise rights under this License despite a
-       previous violation.
-    g. "License Elements" means the following high-level license
-       attributes as selected by Licensor and indicated in the title of
-       this License: Attribution, ShareAlike.
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
 
-   2. Fair Use Rights. Nothing in this license is intended to reduce,
-   limit, or restrict any rights arising from fair use, first sale or
-   other limitations on the exclusive rights of the copyright owner under
-   copyright law or other applicable laws.
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+     wiki.creativecommons.org/Considerations_for_licensors
 
-   3. License Grant. Subject to the terms and conditions of this License,
-   Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
-   perpetual (for the duration of the applicable copyright) license to
-   exercise the rights in the Work as stated below:
-    a. to reproduce the Work, to incorporate the Work into one or more
-       Collective Works, and to reproduce the Work as incorporated in the
-       Collective Works;
-    b. to create and reproduce Derivative Works;
-    c. to distribute copies or phonorecords of, display publicly, perform
-       publicly, and perform publicly by means of a digital audio
-       transmission the Work including as incorporated in Collective
-       Works;
-    d. to distribute copies or phonorecords of, display publicly, perform
-       publicly, and perform publicly by means of a digital audio
-       transmission Derivative Works.
-    e. For the avoidance of doubt, where the work is a musical
-       composition:
-         i. Performance Royalties Under Blanket Licenses. Licensor waives
-            the exclusive right to collect, whether individually or via a
-            performance rights society (e.g. ASCAP, BMI, SESAC),
-            royalties for the public performance or public digital
-            performance (e.g. webcast) of the Work.
-        ii. Mechanical Rights and Statutory Royalties. Licensor waives
-            the exclusive right to collect, whether individually or via a
-            music rights society or designated agent (e.g. Harry Fox
-            Agency), royalties for any phonorecord You create from the
-            Work ("cover version") and distribute, subject to the
-            compulsory license created by 17 USC Section 115 of the US
-            Copyright Act (or the equivalent in other jurisdictions).
-    f. Webcasting Rights and Statutory Royalties. For the avoidance of
-       doubt, where the Work is a sound recording, Licensor waives the
-       exclusive right to collect, whether individually or via a
-       performance-rights society (e.g. SoundExchange), royalties for the
-       public digital performance (e.g. webcast) of the Work, subject to
-       the compulsory license created by 17 USC Section 114 of the US
-       Copyright Act (or the equivalent in other jurisdictions).
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+     wiki.creativecommons.org/Considerations_for_licensees
 
-   The above rights may be exercised in all media and formats whether now
-   known or hereafter devised. The above rights include the right to make
-   such modifications as are technically necessary to exercise the rights
-   in other media and formats. All rights not expressly granted by
-   Licensor are hereby reserved.
+=======================================================================
 
-   4. Restrictions.The license granted in Section 3 above is expressly
-   made subject to and limited by the following restrictions:
-    a. You may distribute, publicly display, publicly perform, or
-       publicly digitally perform the Work only under the terms of this
-       License, and You must include a copy of, or the Uniform Resource
-       Identifier for, this License with every copy or phonorecord of the
-       Work You distribute, publicly display, publicly perform, or
-       publicly digitally perform. You may not offer or impose any terms
-       on the Work that alter or restrict the terms of this License or
-       the recipients' exercise of the rights granted hereunder. You may
-       not sublicense the Work. You must keep intact all notices that
-       refer to this License and to the disclaimer of warranties. You may
-       not distribute, publicly display, publicly perform, or publicly
-       digitally perform the Work with any technological measures that
-       control access or use of the Work in a manner inconsistent with
-       the terms of this License Agreement. The above applies to the Work
-       as incorporated in a Collective Work, but this does not require
-       the Collective Work apart from the Work itself to be made subject
-       to the terms of this License. If You create a Collective Work,
-       upon notice from any Licensor You must, to the extent practicable,
-       remove from the Collective Work any reference to such Licensor or
-       the Original Author, as requested. If You create a Derivative
-       Work, upon notice from any Licensor You must, to the extent
-       practicable, remove from the Derivative Work any reference to such
-       Licensor or the Original Author, as requested.
-    b. You may distribute, publicly display, publicly perform, or
-       publicly digitally perform a Derivative Work only under the terms
-       of this License, a later version of this License with the same
-       License Elements as this License, or a Creative Commons iCommons
-       license that contains the same License Elements as this License
-       (e.g. Attribution-ShareAlike 2.0 Japan). You must include a copy
-       of, or the Uniform Resource Identifier for, this License or other
-       license specified in the previous sentence with every copy or
-       phonorecord of each Derivative Work You distribute, publicly
-       display, publicly perform, or publicly digitally perform. You may
-       not offer or impose any terms on the Derivative Works that alter
-       or restrict the terms of this License or the recipients' exercise
-       of the rights granted hereunder, and You must keep intact all
-       notices that refer to this License and to the disclaimer of
-       warranties. You may not distribute, publicly display, publicly
-       perform, or publicly digitally perform the Derivative Work with
-       any technological measures that control access or use of the Work
-       in a manner inconsistent with the terms of this License Agreement.
-       The above applies to the Derivative Work as incorporated in a
-       Collective Work, but this does not require the Collective Work
-       apart from the Derivative Work itself to be made subject to the
-       terms of this License.
-    c. If you distribute, publicly display, publicly perform, or publicly
-       digitally perform the Work or any Derivative Works or Collective
-       Works, You must keep intact all copyright notices for the Work and
-       give the Original Author credit reasonable to the medium or means
-       You are utilizing by conveying the name (or pseudonym if
-       applicable) of the Original Author if supplied; the title of the
-       Work if supplied; to the extent reasonably practicable, the
-       Uniform Resource Identifier, if any, that Licensor specifies to be
-       associated with the Work, unless such URI does not refer to the
-       copyright notice or licensing information for the Work; and in the
-       case of a Derivative Work, a credit identifying the use of the
-       Work in the Derivative Work (e.g., "French translation of the Work
-       by Original Author," or "Screenplay based on original Work by
-       Original Author"). Such credit may be implemented in any
-       reasonable manner; provided, however, that in the case of a
-       Derivative Work or Collective Work, at a minimum such credit will
-       appear where any other comparable authorship credit appears and in
-       a manner at least as prominent as such other comparable authorship
-       credit.
+Creative Commons Attribution 4.0 International Public License
 
-   5. Representations, Warranties and Disclaimer
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
 
-   UNLESS OTHERWISE AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS
-   THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND
-   CONCERNING THE MATERIALS, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
-   INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
-   FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
-   LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF
-   ERRORS, WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW
-   THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY
-   TO YOU.
 
-   6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY
-   APPLICABLE LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY
-   LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR
-   EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK,
-   EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+Section 1 -- Definitions.
 
-   7. Termination
-    a. This License and the rights granted hereunder will terminate
-       automatically upon any breach by You of the terms of this License.
-       Individuals or entities who have received Derivative Works or
-       Collective Works from You under this License, however, will not
-       have their licenses terminated provided such individuals or
-       entities remain in full compliance with those licenses. Sections
-       1, 2, 5, 6, 7, and 8 will survive any termination of this License.
-    b. Subject to the above terms and conditions, the license granted
-       here is perpetual (for the duration of the applicable copyright in
-       the Work). Notwithstanding the above, Licensor reserves the right
-       to release the Work under different license terms or to stop
-       distributing the Work at any time; provided, however that any such
-       election will not serve to withdraw this License (or any other
-       license that has been, or is required to be, granted under the
-       terms of this License), and this License will continue in full
-       force and effect unless terminated as stated above.
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
 
-   8. Miscellaneous
-    a. Each time You distribute or publicly digitally perform the Work or
-       a Collective Work, the Licensor offers to the recipient a license
-       to the Work on the same terms and conditions as the license
-       granted to You under this License.
-    b. Each time You distribute or publicly digitally perform a
-       Derivative Work, Licensor offers to the recipient a license to the
-       original Work on the same terms and conditions as the license
-       granted to You under this License.
-    c. If any provision of this License is invalid or unenforceable under
-       applicable law, it shall not affect the validity or enforceability
-       of the remainder of the terms of this License, and without further
-       action by the parties to this agreement, such provision shall be
-       reformed to the minimum extent necessary to make such provision
-       valid and enforceable.
-    d. No term or provision of this License shall be deemed waived and no
-       breach consented to unless such waiver or consent shall be in
-       writing and signed by the party to be charged with such waiver or
-       consent.
-    e. This License constitutes the entire agreement between the parties
-       with respect to the Work licensed here. There are no
-       understandings, agreements or representations with respect to the
-       Work not specified here. Licensor shall not be bound by any
-       additional provisions that may appear in any communication from
-       You. This License may not be modified without the mutual written
-       agreement of the Licensor and You.
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
 
-   Creative Commons is not a party to this License, and makes no warranty
-   whatsoever in connection with the Work. Creative Commons will not be
-   liable to You or any party on any legal theory for any damages
-   whatsoever, including without limitation any general, special,
-   incidental or consequential damages arising in connection to this
-   license. Notwithstanding the foregoing two (2) sentences, if Creative
-   Commons has expressly identified itself as the Licensor hereunder, it
-   shall have all rights and obligations of Licensor.
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
 
-   Except for the limited purpose of indicating to the public that the
-   Work is licensed under the CCPL, neither party will use the trademark
-   "Creative Commons" or any related trademark or logo of Creative
-   Commons without the prior written consent of Creative Commons. Any
-   permitted use will be in compliance with Creative Commons'
-   then-current trademark usage guidelines, as may be published on its
-   website or otherwise made available upon request from time to time.
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
 
-   Creative Commons may be contacted at http://creativecommons.org/.
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ By default, it's not possible to add clickable links inside Scratch projects, so
 
 </details>
 
+Again, there may be parts of the repository that have content under different license terms. Double-check the license terms in use at the bottom of each Scratch project's README and follow the license terms listed.
+
+Also make sure to follow the license terms of external content I used. For example, if I used a library someone else made and licensed under the terms of CC-BY 4.0, give credit to them in the same way, and point out that their work is used by mine. I will give credit where credit is due so you know.
+
 > [!NOTE]
-> Originally, the contents of this repository were licensed under a [Creative Commons Attribution-ShareAlike 2.0 license](https://creativecommons.org/licenses/by-sa/2.0/legalcode). Commit [`2a7ad24`](https://github.com/DNin01/Scratch-projects/commit/2a7ad24ea42b27c086543a39e285d13bc9f187e2) was the last version licensed under the terms of CC-BY-SA 2.0, and all future versions use CC-BY 4.0, with some exceptions. For those already reusing content, you have the right to use newer versions of the content under their new license.
+> Originally, the contents of this repository were licensed under a [Creative Commons Attribution-ShareAlike 2.0 license](https://creativecommons.org/licenses/by-sa/2.0/legalcode). Commit [`2a7ad24`](https://github.com/DNin01/Scratch-projects/commit/2a7ad24ea42b27c086543a39e285d13bc9f187e2) was the last version licensed under the terms of CC-BY-SA 2.0, and all future versions use CC-BY 4.0 by default (some parts use different licenses). For those already reusing content, you have the right to use newer versions of the content under their new license terms.
 
 If you use these in a Scratch project you share on the Scratch website, be aware that Scratch is made for kids and linking to GitHub from Scratch might violate their Community Guidelines (I'm not absolutely sure). Please don't not give credit because of that, though.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ You are free to use, adapt, and reshare that content, provided that you give att
 </details>
 
 > [!NOTE]
-> Up until commit [`2a7ad24`](https://github.com/DNin01/Scratch-projects/commit/2a7ad24ea42b27c086543a39e285d13bc9f187e2), the contents of this repository were licensed under a [Creative Commons Attribution-ShareAlike 2.0 license](https://creativecommons.org/licenses/by-sa/2.0/legalcode). For those already reusing content, you have the right to use newer revisions of the content under the new license.
+> Originally, the contents of this repository were licensed under a [Creative Commons Attribution-ShareAlike 2.0 license](https://creativecommons.org/licenses/by-sa/2.0/legalcode). Commit [`2a7ad24`](https://github.com/DNin01/Scratch-projects/commit/2a7ad24ea42b27c086543a39e285d13bc9f187e2) was the last version licensed under the terms of CC-BY-SA 2.0, and all future versions use CC-BY 4.0, with some exceptions. For those already reusing content, you have the right to use newer versions of the content under their new license.
 
 If you use these in a Scratch project you share on the Scratch website, be aware that Scratch is made for kids and linking to GitHub from Scratch might violate their Community Guidelines (I'm not absolutely sure). Please don't not give credit because of that, though.

--- a/README.md
+++ b/README.md
@@ -11,18 +11,20 @@ See [Downloading and Opening](./INSTALLING.md) for instructions. All you need is
 Content in this repository is licensed under a [Creative Commons Attribution 4.0 license](./LICENSE) _unless otherwise stated_.
 
 You are free to use, adapt, and reshare that content, provided that you give attribution (preferably a mention of my name, a link to this repository, and the copyright license in use). It's best to provide attribution both in the repository containing your Scratch project file (if you have one) and inside your Scratch project itself.
-<details open><summary>For example:</summary>
+
+By default, it's not possible to add clickable links inside Scratch projects, so just showing the URL which users can manually type in is sufficient.
+
+<details open><summary>Example</summary>
 
 <p>
 
-> #### In your source code repository
+> #### In your source code repository or documentation
 > Credits:
 > - [Video Player Maker](https://github.com/DNin01/Scratch-projects/tree/main/turbowarp/tools/video-player) by [@DNin01](https://github.com/DNin01) (CC-BY 4.0)
 > #### Inside your Scratch project
 > Credits:
-> - Video Player Maker by DNin01 (CC-BY 4.0)
-> 
-> (links in source code)
+> - Video Player Maker by DNin01 (CC-BY 4.0)<br>
+>   <sup>[github.com/DNin01/Scratch-projects](https://github.com/DNin01/Scratch-projects)</sup>
 
 </p>
 

--- a/README.md
+++ b/README.md
@@ -8,29 +8,27 @@ See [Downloading and Opening](./INSTALLING.md) for instructions. All you need is
 
 ## License and giving credit
 
-All content in this repository is under a [Creative Commons Attribution-ShareAlike 2.0 license](./LICENSE) unless otherwise stated.
+Content in this repository is licensed under a [Creative Commons Attribution 4.0 license](./LICENSE) _unless otherwise stated_.
 
-This means anyone is allowed to use, adapt, and reshare everything I made in here, under the following conditions:
+You are free to use, adapt, and reshare that content, provided that you give attribution (preferably a mention of my name, a link to this repository, and the copyright license in use). It's best to provide attribution both in the repository containing your Scratch project file (if you have one) and inside your Scratch project itself.
+<details open><summary>For example:</summary>
 
-- You give attribution (preferably a mention of my name, a link to this repository, and the copyright license in use). It's best to provide attribution both in the repository containing your Scratch project (if you have one) and inside your Scratch project itself.
-  <details open><summary>For example:</summary>
+<p>
 
-  <p>
-  
-  > #### In your source code repository
-  > Credits:
-  > - [Video Player Maker](https://github.com/DNin01/Scratch-projects/tree/main/turbowarp/tools/video-player) by [@DNin01](https://github.com/DNin01) (CC-BY-SA 2.0)
-  > #### Inside your Scratch project
-  > Credits:
-  > - Video Player Maker by DNin01
-  > 
-  > (links in source code)
-  
-  </p>
+> #### In your source code repository
+> Credits:
+> - [Video Player Maker](https://github.com/DNin01/Scratch-projects/tree/main/turbowarp/tools/video-player) by [@DNin01](https://github.com/DNin01) (CC-BY 4.0)
+> #### Inside your Scratch project
+> Credits:
+> - Video Player Maker by DNin01 (CC-BY 4.0)
+> 
+> (links in source code)
 
-  </details>
-- License your adaptations of the content under the same license.
+</p>
 
-Provided those conditions are met, you can go ahead and use these in your own projects!
+</details>
+
+> [!NOTE]
+> Up until commit [`2a7ad24`](https://github.com/DNin01/Scratch-projects/commit/2a7ad24ea42b27c086543a39e285d13bc9f187e2), the contents of this repository were licensed under a [Creative Commons Attribution-ShareAlike 2.0 license](https://creativecommons.org/licenses/by-sa/2.0/legalcode). For those already reusing content, you have the right to use newer revisions of the content under the new license.
 
 If you use these in a Scratch project you share on the Scratch website, be aware that Scratch is made for kids and linking to GitHub from Scratch might violate their Community Guidelines (I'm not absolutely sure). Please don't not give credit because of that, though.

--- a/turbowarp/proofs-of-concepts/drag-across-windows/LICENSE
+++ b/turbowarp/proofs-of-concepts/drag-across-windows/LICENSE
@@ -1,0 +1,252 @@
+                         Attribution-ShareAlike 2.0
+   CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+   LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN
+   ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+   INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+   REGARDING THE INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR
+   DAMAGES RESULTING FROM ITS USE.
+
+   License
+
+   THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
+   CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS
+   PROTECTED BY COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE
+   WORK OTHER THAN AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS
+   PROHIBITED.
+
+   BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND
+   AGREE TO BE BOUND BY THE TERMS OF THIS LICENSE. THE LICENSOR GRANTS
+   YOU THE RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF
+   SUCH TERMS AND CONDITIONS.
+
+   1. Definitions
+    a. "Collective Work" means a work, such as a periodical issue,
+       anthology or encyclopedia, in which the Work in its entirety in
+       unmodified form, along with a number of other contributions,
+       constituting separate and independent works in themselves, are
+       assembled into a collective whole. A work that constitutes a
+       Collective Work will not be considered a Derivative Work (as
+       defined below) for the purposes of this License.
+    b. "Derivative Work" means a work based upon the Work or upon the
+       Work and other pre-existing works, such as a translation, musical
+       arrangement, dramatization, fictionalization, motion picture
+       version, sound recording, art reproduction, abridgment,
+       condensation, or any other form in which the Work may be recast,
+       transformed, or adapted, except that a work that constitutes a
+       Collective Work will not be considered a Derivative Work for the
+       purpose of this License. For the avoidance of doubt, where the
+       Work is a musical composition or sound recording, the
+       synchronization of the Work in timed-relation with a moving image
+       ("synching") will be considered a Derivative Work for the purpose
+       of this License.
+    c. "Licensor" means the individual or entity that offers the Work
+       under the terms of this License.
+    d. "Original Author" means the individual or entity who created the
+       Work.
+    e. "Work" means the copyrightable work of authorship offered under
+       the terms of this License.
+    f. "You" means an individual or entity exercising rights under this
+       License who has not previously violated the terms of this License
+       with respect to the Work, or who has received express permission
+       from the Licensor to exercise rights under this License despite a
+       previous violation.
+    g. "License Elements" means the following high-level license
+       attributes as selected by Licensor and indicated in the title of
+       this License: Attribution, ShareAlike.
+
+   2. Fair Use Rights. Nothing in this license is intended to reduce,
+   limit, or restrict any rights arising from fair use, first sale or
+   other limitations on the exclusive rights of the copyright owner under
+   copyright law or other applicable laws.
+
+   3. License Grant. Subject to the terms and conditions of this License,
+   Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+   perpetual (for the duration of the applicable copyright) license to
+   exercise the rights in the Work as stated below:
+    a. to reproduce the Work, to incorporate the Work into one or more
+       Collective Works, and to reproduce the Work as incorporated in the
+       Collective Works;
+    b. to create and reproduce Derivative Works;
+    c. to distribute copies or phonorecords of, display publicly, perform
+       publicly, and perform publicly by means of a digital audio
+       transmission the Work including as incorporated in Collective
+       Works;
+    d. to distribute copies or phonorecords of, display publicly, perform
+       publicly, and perform publicly by means of a digital audio
+       transmission Derivative Works.
+    e. For the avoidance of doubt, where the work is a musical
+       composition:
+         i. Performance Royalties Under Blanket Licenses. Licensor waives
+            the exclusive right to collect, whether individually or via a
+            performance rights society (e.g. ASCAP, BMI, SESAC),
+            royalties for the public performance or public digital
+            performance (e.g. webcast) of the Work.
+        ii. Mechanical Rights and Statutory Royalties. Licensor waives
+            the exclusive right to collect, whether individually or via a
+            music rights society or designated agent (e.g. Harry Fox
+            Agency), royalties for any phonorecord You create from the
+            Work ("cover version") and distribute, subject to the
+            compulsory license created by 17 USC Section 115 of the US
+            Copyright Act (or the equivalent in other jurisdictions).
+    f. Webcasting Rights and Statutory Royalties. For the avoidance of
+       doubt, where the Work is a sound recording, Licensor waives the
+       exclusive right to collect, whether individually or via a
+       performance-rights society (e.g. SoundExchange), royalties for the
+       public digital performance (e.g. webcast) of the Work, subject to
+       the compulsory license created by 17 USC Section 114 of the US
+       Copyright Act (or the equivalent in other jurisdictions).
+
+   The above rights may be exercised in all media and formats whether now
+   known or hereafter devised. The above rights include the right to make
+   such modifications as are technically necessary to exercise the rights
+   in other media and formats. All rights not expressly granted by
+   Licensor are hereby reserved.
+
+   4. Restrictions.The license granted in Section 3 above is expressly
+   made subject to and limited by the following restrictions:
+    a. You may distribute, publicly display, publicly perform, or
+       publicly digitally perform the Work only under the terms of this
+       License, and You must include a copy of, or the Uniform Resource
+       Identifier for, this License with every copy or phonorecord of the
+       Work You distribute, publicly display, publicly perform, or
+       publicly digitally perform. You may not offer or impose any terms
+       on the Work that alter or restrict the terms of this License or
+       the recipients' exercise of the rights granted hereunder. You may
+       not sublicense the Work. You must keep intact all notices that
+       refer to this License and to the disclaimer of warranties. You may
+       not distribute, publicly display, publicly perform, or publicly
+       digitally perform the Work with any technological measures that
+       control access or use of the Work in a manner inconsistent with
+       the terms of this License Agreement. The above applies to the Work
+       as incorporated in a Collective Work, but this does not require
+       the Collective Work apart from the Work itself to be made subject
+       to the terms of this License. If You create a Collective Work,
+       upon notice from any Licensor You must, to the extent practicable,
+       remove from the Collective Work any reference to such Licensor or
+       the Original Author, as requested. If You create a Derivative
+       Work, upon notice from any Licensor You must, to the extent
+       practicable, remove from the Derivative Work any reference to such
+       Licensor or the Original Author, as requested.
+    b. You may distribute, publicly display, publicly perform, or
+       publicly digitally perform a Derivative Work only under the terms
+       of this License, a later version of this License with the same
+       License Elements as this License, or a Creative Commons iCommons
+       license that contains the same License Elements as this License
+       (e.g. Attribution-ShareAlike 2.0 Japan). You must include a copy
+       of, or the Uniform Resource Identifier for, this License or other
+       license specified in the previous sentence with every copy or
+       phonorecord of each Derivative Work You distribute, publicly
+       display, publicly perform, or publicly digitally perform. You may
+       not offer or impose any terms on the Derivative Works that alter
+       or restrict the terms of this License or the recipients' exercise
+       of the rights granted hereunder, and You must keep intact all
+       notices that refer to this License and to the disclaimer of
+       warranties. You may not distribute, publicly display, publicly
+       perform, or publicly digitally perform the Derivative Work with
+       any technological measures that control access or use of the Work
+       in a manner inconsistent with the terms of this License Agreement.
+       The above applies to the Derivative Work as incorporated in a
+       Collective Work, but this does not require the Collective Work
+       apart from the Derivative Work itself to be made subject to the
+       terms of this License.
+    c. If you distribute, publicly display, publicly perform, or publicly
+       digitally perform the Work or any Derivative Works or Collective
+       Works, You must keep intact all copyright notices for the Work and
+       give the Original Author credit reasonable to the medium or means
+       You are utilizing by conveying the name (or pseudonym if
+       applicable) of the Original Author if supplied; the title of the
+       Work if supplied; to the extent reasonably practicable, the
+       Uniform Resource Identifier, if any, that Licensor specifies to be
+       associated with the Work, unless such URI does not refer to the
+       copyright notice or licensing information for the Work; and in the
+       case of a Derivative Work, a credit identifying the use of the
+       Work in the Derivative Work (e.g., "French translation of the Work
+       by Original Author," or "Screenplay based on original Work by
+       Original Author"). Such credit may be implemented in any
+       reasonable manner; provided, however, that in the case of a
+       Derivative Work or Collective Work, at a minimum such credit will
+       appear where any other comparable authorship credit appears and in
+       a manner at least as prominent as such other comparable authorship
+       credit.
+
+   5. Representations, Warranties and Disclaimer
+
+   UNLESS OTHERWISE AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS
+   THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND
+   CONCERNING THE MATERIALS, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
+   INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
+   FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
+   LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF
+   ERRORS, WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW
+   THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY
+   TO YOU.
+
+   6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY
+   APPLICABLE LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY
+   LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR
+   EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK,
+   EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+   7. Termination
+    a. This License and the rights granted hereunder will terminate
+       automatically upon any breach by You of the terms of this License.
+       Individuals or entities who have received Derivative Works or
+       Collective Works from You under this License, however, will not
+       have their licenses terminated provided such individuals or
+       entities remain in full compliance with those licenses. Sections
+       1, 2, 5, 6, 7, and 8 will survive any termination of this License.
+    b. Subject to the above terms and conditions, the license granted
+       here is perpetual (for the duration of the applicable copyright in
+       the Work). Notwithstanding the above, Licensor reserves the right
+       to release the Work under different license terms or to stop
+       distributing the Work at any time; provided, however that any such
+       election will not serve to withdraw this License (or any other
+       license that has been, or is required to be, granted under the
+       terms of this License), and this License will continue in full
+       force and effect unless terminated as stated above.
+
+   8. Miscellaneous
+    a. Each time You distribute or publicly digitally perform the Work or
+       a Collective Work, the Licensor offers to the recipient a license
+       to the Work on the same terms and conditions as the license
+       granted to You under this License.
+    b. Each time You distribute or publicly digitally perform a
+       Derivative Work, Licensor offers to the recipient a license to the
+       original Work on the same terms and conditions as the license
+       granted to You under this License.
+    c. If any provision of this License is invalid or unenforceable under
+       applicable law, it shall not affect the validity or enforceability
+       of the remainder of the terms of this License, and without further
+       action by the parties to this agreement, such provision shall be
+       reformed to the minimum extent necessary to make such provision
+       valid and enforceable.
+    d. No term or provision of this License shall be deemed waived and no
+       breach consented to unless such waiver or consent shall be in
+       writing and signed by the party to be charged with such waiver or
+       consent.
+    e. This License constitutes the entire agreement between the parties
+       with respect to the Work licensed here. There are no
+       understandings, agreements or representations with respect to the
+       Work not specified here. Licensor shall not be bound by any
+       additional provisions that may appear in any communication from
+       You. This License may not be modified without the mutual written
+       agreement of the Licensor and You.
+
+   Creative Commons is not a party to this License, and makes no warranty
+   whatsoever in connection with the Work. Creative Commons will not be
+   liable to You or any party on any legal theory for any damages
+   whatsoever, including without limitation any general, special,
+   incidental or consequential damages arising in connection to this
+   license. Notwithstanding the foregoing two (2) sentences, if Creative
+   Commons has expressly identified itself as the Licensor hereunder, it
+   shall have all rights and obligations of Licensor.
+
+   Except for the limited purpose of indicating to the public that the
+   Work is licensed under the CCPL, neither party will use the trademark
+   "Creative Commons" or any related trademark or logo of Creative
+   Commons without the prior written consent of Creative Commons. Any
+   permitted use will be in compliance with Creative Commons'
+   then-current trademark usage guidelines, as may be published on its
+   website or otherwise made available upon request from time to time.
+
+   Creative Commons may be contacted at http://creativecommons.org/.

--- a/turbowarp/proofs-of-concepts/drag-across-windows/README.md
+++ b/turbowarp/proofs-of-concepts/drag-across-windows/README.md
@@ -27,7 +27,7 @@ This is mostly a proof of concept to show that this is possible and to try somet
 - You have to click twice, once to pick up and once to place. The reason I went with this behavior is because, in Windows at least, if you hold down the mouse button while moving the cursor outside the window, only that window will be able to tell where your mouse is going and that your mouse button is down, until you release it.
 - If the clones acting as the draggable items are running code, then the code will be restarted when the item is placed. This happens because when you pick up the item, the clone is actually deleted and the parent sprite takes on its appearance, then a new clone is created when you place it.
 
-## Credits
+## Credits and license
 
 Thanks to the following [TurboWarp extensions](https://extensions.turbowarp.org/) for making this possible:
 - [Local Storage](https://extensions.turbowarp.org/local-storage.js)
@@ -35,8 +35,6 @@ Thanks to the following [TurboWarp extensions](https://extensions.turbowarp.org/
 
 I also used the [Runtime Options](https://extensions.turbowarp.org/runtime-options.js) extension to make the project compatible with any stage size.
 
-The shape tiles come from my project [Shape Board Pro](https://scratch.mit.edu/projects/798778469/) on Scratch, which is under a CC-BY-SA 2.0 license.
+The shape tiles come from my project [Shape Board Pro](https://scratch.mit.edu/projects/798778469/) on Scratch, which is under a CC-BY-SA 2.0 license; (Ͻ) 2023 D-ScratchNinja.
 
----
-
-(Ͻ) 2023 DNin01 from GitHub. Available under a CC-BY-SA 2.0 license.
+Drag Across Windows as a whole is licensed under the terms of CC-BY-SA 2.0, (Ͻ) 2024 DNin01 from GitHub. The code is licensed separately, under the terms of CC-BY 4.0, (Ͻ) 2024 DNin01 from GitHub.

--- a/turbowarp/proofs-of-concepts/drag-across-windows/README.md
+++ b/turbowarp/proofs-of-concepts/drag-across-windows/README.md
@@ -35,6 +35,6 @@ Thanks to the following [TurboWarp extensions](https://extensions.turbowarp.org/
 
 I also used the [Runtime Options](https://extensions.turbowarp.org/runtime-options.js) extension to make the project compatible with any stage size.
 
-The shape tiles come from my project [Shape Board Pro](https://scratch.mit.edu/projects/798778469/) on Scratch, which is under a CC-BY-SA 2.0 license; (Ͻ) 2023 D-ScratchNinja.
+The shape tile images come from my project [Shape Board Pro](https://scratch.mit.edu/projects/798778469/) on Scratch, which is under a CC-BY-SA 2.0 license; (Ͻ) 2023 D-ScratchNinja.
 
 Drag Across Windows as a whole is licensed under the terms of CC-BY-SA 2.0, (Ͻ) 2024 DNin01 from GitHub. The code is licensed separately, under the terms of CC-BY 4.0, (Ͻ) 2024 DNin01 from GitHub.

--- a/turbowarp/proofs-of-concepts/drag-across-windows/README.md
+++ b/turbowarp/proofs-of-concepts/drag-across-windows/README.md
@@ -37,4 +37,4 @@ I also used the [Runtime Options](https://extensions.turbowarp.org/runtime-optio
 
 The shape tile images come from my project [Shape Board Pro](https://scratch.mit.edu/projects/798778469/) on Scratch, which is under a CC-BY-SA 2.0 license; (Ͻ) 2023 D-ScratchNinja.
 
-Drag Across Windows as a whole is licensed under the terms of CC-BY-SA 2.0, (Ͻ) 2024 DNin01 from GitHub. The code is licensed separately, under the terms of CC-BY 4.0, (Ͻ) 2024 DNin01 from GitHub.
+Drag Across Windows as a whole is licensed under the terms of CC-BY-SA 2.0, (Ͻ) 2024 DNin01 from GitHub. Its code is licensed separately, under the terms of CC-BY 4.0, (Ͻ) 2024 DNin01 from GitHub.

--- a/turbowarp/tools/meter-and-slider/README.md
+++ b/turbowarp/tools/meter-and-slider/README.md
@@ -47,4 +47,4 @@ Thanks to [Vadik1](https://scratch.mit.edu/users/Vadik1/)'s [Clipping & Blending
 
 ---
 
-(Ͻ) 2023 DNin01 from GitHub. Available under a CC-BY-SA 2.0 license.
+(Ͻ) 2024 DNin01 from GitHub. Available under a CC-BY 4.0 license.

--- a/turbowarp/tools/video-player/README.md
+++ b/turbowarp/tools/video-player/README.md
@@ -59,4 +59,4 @@ Thanks to the following [TurboWarp extensions](https://extensions.turbowarp.org/
 
 ---
 
-(Ͻ) 2023 DNin01 from GitHub. Available under a CC-BY-SA 2.0 license.
+(Ͻ) 2024 DNin01 from GitHub. Available under a CC-BY 4.0 license.


### PR DESCRIPTION
Resolves #11

Updates the license of the whole repository to CC-BY 4.0, catching us up and granting the ability to share derivatives under a different license, which just feels like it removes some loopholes.

Drag Across Windows will keep using a CC-BY-SA 2.0 license, although its code will be available under a CC-BY 4.0 license.

These changes are not effective until the pull request is merged.